### PR TITLE
Allow GuidoScore.outputString without writing to file

### DIFF
--- a/Ctk classes/Guido.sc
+++ b/Ctk classes/Guido.sc
@@ -82,15 +82,7 @@ GuidoScore : GuidoObj {
 	output {arg pathname, mode = "w";
 		var string, eventstring;
 		file = File.new(pathname, mode);
-		file.write("%% SuperCollider output from " ++ Date.localtime ++ "\n");
-		file.write("%% Comments (%) after musical objects denote measure, beat (if supplied) \n");
-		file.write("{\n");
-		score.do({arg me, i;
-			file.write("%%Voice" ++ i ++ "\n");
-			me.output(file);
-			(i != (score.size - 1)).if({file.write(",")});
-			});
-		file.write("}");
+		file.write(this.outputString);
 		file.close;
 		}
 	}
@@ -149,14 +141,7 @@ GuidoPart : GuidoObj {
 		}
 
 	output {arg file;
-		var string, eventstring, initMeter, currentMeter, currentMeasure, theseevents;
-		file.write("[\n");
-		file.write("\\staff<\""++staffid.asString++"\"> ");
-		instr.notNil.if({file.write("\\instr<\""++instr.asString++"\"> ")});
-		currentMeasure = 1;
-		file.write("\\"++stemdir.asString++" \n");
-		events.do{arg me; me.output(file)};
-		file.write("]\n");
+		file.write(this.outputString);
 		}
 	}
 

--- a/Ctk classes/Guido.sc
+++ b/Ctk classes/Guido.sc
@@ -64,6 +64,21 @@ GuidoScore : GuidoObj {
 			})
 		}
 
+	outputString {
+		var out, string, eventstring;
+		out = [];
+		out = out.add("%% SuperCollider output from " ++ Date.localtime ++ "\n");
+		out = out.add("%% Comments (%) after musical objects denote measure, beat (if supplied) \n");
+		out = out.add("{\n");
+		score.do({arg me, i;
+			out = out.add("%%Voice" ++ i ++ "\n");
+			out = out.add(me.outputString);
+			(i != (score.size - 1)).if({out = out.add(",")});
+			});
+		out = out.add("}");
+		^out.join("");
+		}
+
 	output {arg pathname, mode = "w";
 		var string, eventstring;
 		file = File.new(pathname, mode);
@@ -118,6 +133,19 @@ GuidoPart : GuidoObj {
 				"It appears you are trying to add a non-GuidoEvent to a GuidoPart or GuidoPart".warn;
 				});
 			})
+		}
+
+	outputString {
+		var out, string, eventstring, initMeter, currentMeter, currentMeasure, theseevents;
+		out = [];
+		out = out.add("[\n");
+		out = out.add("\\staff<\""++staffid.asString++"\"> ");
+		instr.notNil.if({ out.add("\\instr<\""++instr.asString++"\"> ") });
+		currentMeasure = 1;
+		out = out.add("\\"++stemdir.asString++" \n");
+		events.do{arg me; out = out.add(me.outputString)};
+		out = out.add("]\n");
+		^out.join("");
 		}
 
 	output {arg file;


### PR DESCRIPTION
GuidoScore can only produce output by writing to a file. This commit adds a new method outputString that bypasses this operation and simply returns the output string.

The motivation here is for interfacing with INScore, where Guido scores must be sent inside OSC messages. Write a file to disk is completely unnecessary (and inefficient) in this case.
