### PR TITLE
Add CtkControl-getSynchronous. Change CtkScore:groupTogether allow for large numbers of buffers in a score.

### DIFF
--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -2217,6 +2217,12 @@ CtkBuffer : CtkObj {
 
 CtkBus : CtkObj {
 	var <server, <bus, <numChans;
+
+  // synonyms 
+	numChannels {^numChans}
+	busnum {^bus}
+	index {^bus}
+
 }
 
 CtkControl : CtkBus {

--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -2474,6 +2474,15 @@ CtkControl : CtkBus {
 		server.sendMsg(\c_get, bus);
 	}
 
+	// indexOffset is for multichannel busses
+	getSynchronous { |indexOffset=0|
+		^try {
+			server.getControlBusValue(bus+indexOffset)
+		} { |error|
+			error.errorString.postln; nil
+		}
+	}
+
 	+ { arg index;
 		^this.at(index)
 	}


### PR DESCRIPTION
Add getSynchronous method to CtkControl. Modify CtkScore:groupTogether to allow for large numbers of buffers in a score.
