### PR TITLE
Add some bus-like functionality

### DIFF
--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -2458,6 +2458,15 @@ CtkControl : CtkBus {
 		server.sendMsg(\c_get, bus);
 	}
 
+	// indexOffset is for multichannel busses
+	getSynchronous { |indexOffset=0|
+		^try {
+			server.getControlBusValue(bus+indexOffset)
+		} { |error|
+			error.errorString.postln; nil
+		}
+	}
+
 	+ { arg index;
 		^this.at(index)
 	}

--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -2196,6 +2196,11 @@ CtkBuffer : CtkObj {
 
 CtkBus : CtkObj {
 	var <server, <bus, <numChans;
+
+	// synonyms
+	numChannels {^numChans}
+	busnum {^bus}
+	index {^bus}
 }
 
 CtkControl : CtkBus {


### PR DESCRIPTION
Add getSynchronous method to CtkControl, and synonyms to CtkBus, one of which fixes a bug of misreporting the numChannels.
