### PR TITLE
Ctk buffer supernova fix

### DIFF
--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -240,12 +240,12 @@ CtkScore : CtkObj {
 					data = me.collection.collectAs({|item| item}, FloatArray);
 					(data.size / 1024).floor.do({arg i;
 						this.add(CtkMsg(me.server, 0.0, [\b_setn, me.bufnum, i * 1024, 1024] ++
-							data[(i*1024).asInt..((i*1024)+1023).asInt]));
+							data[(i*1024).asInteger..((i*1024)+1023).asInteger]));
 					});
 					chunk = (data.size / 1024).floor * 1024;
 					(data.size > chunk).if({
 						this.add(CtkMsg(me.server, 0.0, [\b_setn, me.bufnum, chunk, data.size-chunk-1] ++
-							data[chunk.asInt..(data.size-chunk-1).asInt]));
+							data[chunk.asInteger..(data.size-chunk-1).asInteger]));
 					});
 				});
 				(me.closeBundle.notNil).if({
@@ -1854,20 +1854,20 @@ CtkBuffer : CtkObj {
 				// check if channels array is specified
 				nFrames = numFrames ?? {0};
 				channels.notNil.if({
-					bundle = [\b_allocReadChannel, bufnum, path, startFrame, nFrames] ++ channels;
+					bundle = [\b_allocReadChannel, bufnum, path, startFrame, nFrames.asInteger] ++ channels;
 					}, {
-					bundle = [\b_allocRead, bufnum, path, startFrame, nFrames];
+					bundle = [\b_allocRead, bufnum, path, startFrame, nFrames.asInteger];
 					});
 				} {// path, size ( for DiskIn )
 				path.notNil && size.notNil
 				} {
 				nFrames = size; //numFrames ?? {size};
 				channels.notNil.if({
-					bundle = [\b_alloc, bufnum, size, numChannels,
-						[\b_readChannel, bufnum, path, startFrame, nFrames, 0, 1] ++ channels];
+					bundle = [\b_alloc, bufnum, size.asInteger, numChannels,
+						[\b_readChannel, bufnum, path, startFrame, nFrames.asInteger, 0, 1] ++ channels];
 					}, {
 					bundle = [\b_alloc, bufnum, size, numChannels,
-						[\b_read, bufnum, path, startFrame, nFrames, 0, 1]];
+						[\b_read, bufnum, path, startFrame, nFrames.asInteger, 0, 1]];
 					});
 				closeBundle = [\b_close, bufnum];
 				} { /// just allocate memory (for delays, FFTs etc.)
@@ -1875,7 +1875,7 @@ CtkBuffer : CtkObj {
 				} {
 				numChannels = numChannels ?? {1};
 				numFrames = size / numChannels;
-				bundle = [\b_alloc, bufnum, size, numChannels];
+				bundle = [\b_alloc, bufnum, size.asInteger, numChannels];
 				};
 			freeBundle = [\b_free, bufnum];
 			}, {
@@ -1997,7 +1997,7 @@ CtkBuffer : CtkObj {
 	read {arg time = 0.0, path, fileFrameStart = 0, numFrames, bufStartFrame = 0,
 			leaveOpen = false, completionMessage, action;
 		var bund;
-		bund = [\b_read, bufnum, path, fileFrameStart, (numFrames ? -1).asInt,
+		bund = [\b_read, bufnum, path, fileFrameStart, (numFrames ? -1).asInteger,
 			bufStartFrame, leaveOpen.binaryValue, completionMessage.value(this)];
 		this.bufferFunc(time, bund, action);
 	}

--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -2116,7 +2116,7 @@ CtkBuffer : CtkObj {
 
 	// checks if this is a live, active buffer for real-time use, or being used to build a CtkScore
 	bufferFunc {arg time, bund, action;
-		var cond, id, command, syncUsingDoneMsg = true;
+		var cond;
 		isPlaying.if({
 			SystemClock.sched(time, {
 				Routine.run({

--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -2039,28 +2039,28 @@ CtkBuffer : CtkObj {
 
 	// write a buffer out to a file. For DiskOut usage in real-time, use openWrite and closeWrite
 	write {arg time = 0.0, path, headerFormat = 'aiff', sampleFormat='int16',
-			numberOfFrames = -1, startingFrame = 0;
+			numberOfFrames = -1, startingFrame = 0, action;
 		var bund;
 		bund = [\b_write, bufnum, path, headerFormat, sampleFormat, numberOfFrames.asInteger,
 			startingFrame, 0];
-		this.bufferFunc(time, bund);
+		this.bufferFunc(time, bund, action);
 		}
 
 	// prepare a buffer for use with DiskOut
 	openWrite {arg time = 0.0, path, headerFormat = 'aiff', sampleFormat='int16',
-			numberOfFrames = -1, startingFrame = 0;
+			numberOfFrames = -1, startingFrame = 0, action;
 		var bund;
 		isOpen = true;
 		bund = [\b_write, bufnum, path, headerFormat, sampleFormat, numberOfFrames.asInteger,
 			startingFrame, 1];
-		this.bufferFunc(time, bund);
+		this.bufferFunc(time, bund, action);
 		}
 
-	closeWrite {arg time = 0.0;
+	closeWrite {arg time = 0.0, action;
 		var bund;
 		isOpen = false;
 		bund = [\b_close, bufnum];
-		this.bufferFunc(time, bund);
+		this.bufferFunc(time, bund, action);
 		}
 
 	gen {arg time = 0.0, cmd, normalize = 0, wavetable = 0, clear = 1 ... args;
@@ -2163,9 +2163,8 @@ CtkBuffer : CtkObj {
 				condition = Condition.new;
 				path = PathName.tmp ++ this.hash.asString;
 
-				msg = this.write(0.0, path, "aiff", "float", count, index);
-				latency.wait;
-				server.sync(condition);
+				msg = this.write(0.0, path, "aiff", "float", count, index, {condition.test_(true); condition.signal});
+				condition.wait;
 				file = SoundFile.new;
 				protect {
 					file.openRead(path);

--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -2041,7 +2041,7 @@ CtkBuffer : CtkObj {
 	write {arg time = 0.0, path, headerFormat = 'aiff', sampleFormat='int16',
 			numberOfFrames = -1, startingFrame = 0;
 		var bund;
-		bund = [\b_write, bufnum, path, headerFormat, sampleFormat, numberOfFrames,
+		bund = [\b_write, bufnum, path, headerFormat, sampleFormat, numberOfFrames.asInteger,
 			startingFrame, 0];
 		this.bufferFunc(time, bund);
 		}
@@ -2051,7 +2051,7 @@ CtkBuffer : CtkObj {
 			numberOfFrames = -1, startingFrame = 0;
 		var bund;
 		isOpen = true;
-		bund = [\b_write, bufnum, path, headerFormat, sampleFormat, numberOfFrames,
+		bund = [\b_write, bufnum, path, headerFormat, sampleFormat, numberOfFrames.asInteger,
 			startingFrame, 1];
 		this.bufferFunc(time, bund);
 		}

--- a/HelpSource/Classes/CtkBuffer.schelp
+++ b/HelpSource/Classes/CtkBuffer.schelp
@@ -154,6 +154,8 @@ ARGUMENT:: numberOfFrames
 The number of frames to write. The defaults is -1 (all frames).
 ARGUMENT:: startingFrame
 The starting frame of the buffer to write. The default is 0.
+ARGUMENT:: action
+An action to be executed when the buffer is ready
 
 METHOD:: openWrite
 Write a buffer to file at path. This file is left open for use by DiskOut, and will need to have the link::#-closeWrite:: method	applied to the CtkBuffer.
@@ -169,11 +171,15 @@ ARGUMENT:: numberOfFrames
 The number of frames to write. The defaults is -1 (all frames).
 ARGUMENT:: startingFrame
 The starting frame of the buffer to write. The default is 0.
+ARGUMENT:: action
+An action to be executed when the buffer is ready
 
 METHOD:: closeWrite
 Close and write the header for a file that had been created and left open with openWrite.
 argument::time
 In real-time mode, 'time' schedules the closeWrite in the future.
+ARGUMENT:: action
+An action to be executed when the buffer is ready
 
 METHOD:: fill
 Fill a buffer with newValue starting at sample start for numSamples.
@@ -220,6 +226,8 @@ ARGUMENT:: buf
 impulse response buffer
 ARGUMENT:: fftsize
 spectral convolution partition size
+ARGUMENT:: action
+An action to be executed when the buffer is ready
 returns::
 CtkBuffer for use with PartConv
 

--- a/HelpSource/Classes/CtkBuffer.schelp
+++ b/HelpSource/Classes/CtkBuffer.schelp
@@ -480,7 +480,7 @@ playfun = {arg starttime, gestdur, rateenv;
 	while({
 		ratio = now / gestdur;
 		rate = rateenv[ratio];
-		play.note(now + starttime, 0.5)
+		play.new(now + starttime, 0.5)
 			.buffer_(buf) // the arg will parse the CtkBuffer and grab its bufnum
 			.rate_(CtkControl.env(Env([rate, 1], [1])))
 			.dur_(0.5)
@@ -499,6 +499,7 @@ score.play
 // uncomment to save the score
 //score.saveToFile("~/Desktop/test.sc".standardizePath);
 // uncomment to write the score to a soundfile
-//score.write("~/Desktop/test.aiff".standardizePath, options: ServerOptions.new.numOutputBusChannels_(2));
+//score.write("~/Desktop/test.aiff".standardizePath,
+//	options: ServerOptions.new.numOutputBusChannels_(2));
 )
 ::

--- a/HelpSource/Classes/CtkBuffer.schelp
+++ b/HelpSource/Classes/CtkBuffer.schelp
@@ -480,7 +480,7 @@ playfun = {arg starttime, gestdur, rateenv;
 	while({
 		ratio = now / gestdur;
 		rate = rateenv[ratio];
-		play.new(now + starttime, 0.5)
+		play.note(now + starttime, 0.5)
 			.buffer_(buf) // the arg will parse the CtkBuffer and grab its bufnum
 			.rate_(CtkControl.env(Env([rate, 1], [1])))
 			.dur_(0.5)
@@ -499,7 +499,6 @@ score.play
 // uncomment to save the score
 //score.saveToFile("~/Desktop/test.sc".standardizePath);
 // uncomment to write the score to a soundfile
-//score.write("~/Desktop/test.aiff".standardizePath,
-//	options: ServerOptions.new.numOutputBusChannels_(2));
+//score.write("~/Desktop/test.aiff".standardizePath, options: ServerOptions.new.numOutputBusChannels_(2));
 )
 ::


### PR DESCRIPTION
Hi @joshpar 
Supernova fails when it receives buffer messages with number of frames being floats. This has been discussed: https://github.com/supercollider/supercollider/issues/1827 
I don't think there's a consensus how to proceed, but for the time being, the Buffer class is sending buffer messages with numFrames being an integer. I made the relevant changes for CtkBuffer so it does the same. I also updated methods to .asInteger (as opposed to .asInt) for consistency, I hope that's OK.
Marcin
PS. sorry it's messy between the two PRs