### PR TITLE
Timing improvements/changes

### DIFF
--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -1608,7 +1608,9 @@ CtkNote : CtkNode {
 					})
 				});
 				if(sendImmediately, {
-					server.sendBundle(nil, bund.messages);
+					bund.messages.do({|thisMsg| //not sure if we ever have more than one...
+						server.sendBundle(nil, thisMsg);
+					});
 				}, {
 					bund.send(server, latency);
 				});
@@ -1622,10 +1624,10 @@ CtkNote : CtkNode {
 					this.playAutomations;
 				})
 			};
-			if(starttime.notNil || latency.notNil, {
+			if(starttime.notNil && latency.notNil, {
 				SystemClock.sched(starttime, {playFunc.value(false)});
 			}, {
-				playFunc.value(true); //if starttime is nil, send immediately
+				playFunc.value(true); //if starttime or latency is nil, send immediately
 			});
 			^this;
 		}, {


### PR DESCRIPTION
Hi Josh,

I was working on making some changes to allow Ctk to work with no latency (starting synths and groups immediately, e.g. using external controllers), either by providing global `CtkObj.latency_(nil)` or using `nil` as start time for individual objects. Could you take a look and let me know what you think?

I also changed buffer loading slightly, not sure if that's OK. Previously, the buffer loading would always happen in a new Routine, and one needed to use `onComplete` + `Condition` to wait for loading. Now, I've set the default loading time to `nil`, and when it's nil, it will run with `.forkIfNeeded`. This allows for e.g. loading numerous buffers in succession without extra condition, or something like this:

```
(
fork{
	b = CtkBuffer.playbuf(Platform.resourceDir +/+ "sounds/a11wlk01-44_1.aiff").load(); //syncs automatically
	x = {PlayBuf.ar(1, b)}.play; //plays, no error
}
)
```

In general I don't think the default behavior changes (save for the buffer loading, which is by default immediate and will not start a new routine if started within one), but I'd appreciate if you could give it some thought and test.
Thank you!
Marcin