### PR TITLE
fixed buffer overflow bug

### DIFF
--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -246,8 +246,8 @@ CtkScore : CtkObj {
 					});
 					chunk = (data.size / 1024).floor * 1024;
 					(data.size > chunk).if({
-						this.add(CtkMsg(me.server, 0.0, [\b_setn, me.bufnum, chunk, data.size-chunk-1] ++
-							data[chunk.asInteger..(data.size-chunk-1).asInteger]));
+						this.add(CtkMsg(me.server, 0.0, [\b_setn, me.bufnum, chunk, data.size-chunk] ++
+							data[chunk.asInteger..]));
 					});
 				});
 				(me.closeBundle.notNil).if({


### PR DESCRIPTION
This bug was causing a `'b_setn'` message to be most of the buffer after it had been chunked into 1024 samples per message. The `data.size - chunk - 1` was always a number much much smaller than chunk and so the array was being indexed backwards. Also the amount of samples to set here should be `data.size - chunk`.