### PR TITLE
fix remote servers in CtkNoteObject

### DIFF
--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -747,13 +747,13 @@ CtkNoteObject {
 
 	// for loading directly to a specific server
 	load {arg ... servers;
-		server.do({arg aServer;
+		servers.do({arg aServer;
 			synthdef.load(aServer)
 		})
 		}
 
 	send {arg ... servers;
-		server.do({arg aServer;
+		servers.do({arg aServer;
 			synthdef.send(aServer)
 		})
 		}


### PR DESCRIPTION
This bug prevented sending CtkSynthDefs to remote servers.

BTW documentation states that one doesn't need to call `.send` on a CtkSynthDef. Is it a bug or an intended behavior that the SynthDefs are not automatically sent to remote servers?