### PR TITLE
Recognize standard addActions

### DIFF
--- a/Ctk classes/CTK.sc
+++ b/Ctk classes/CTK.sc
@@ -66,7 +66,14 @@ CtkObj {
 			1 -> 1,
 			2 -> 2,
 			3 -> 3,
-			4 -> 4
+			4 -> 4,
+			\addToHead -> 0,
+			\addToTail -> 1,
+			\addBefore -> 2,
+			\addAfter -> 3,
+			\addReplace -> 4,
+			\h -> 0,
+			\t -> 1,
 			];
 		}
 	}


### PR DESCRIPTION
I was recently mixing code that uses regular `Synth`s and Ctk objects and I was caught by the fact that Ctk (silently) doesn't respond to "standard" addAction symbols. 

I propose to add support for these, on top of the symbols used already. 
IMO this can be done without changes to the docs (the old behavior stays the same), but I'd be happy to add it if you'd like.